### PR TITLE
Only run latency estimator once and save profile to a file

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -43,4 +43,5 @@ jobs:
             cd build
             test/cpp/quake_tests --gtest_filter=IndexPartitionTest.* 
             test/cpp/quake_tests --gtest_filter=DynamicInvertedListTest.*
+            test/cpp/quake_tests --gtest_filter=ListScanLatencyEstimatorTest.*
             test/cpp/quake_tests --gtest_filter=DynamicIVFTest.*

--- a/src/cpp/src/maintenance_policies.cpp
+++ b/src/cpp/src/maintenance_policies.cpp
@@ -267,9 +267,18 @@ QueryCostMaintenance::QueryCostMaintenance(std::shared_ptr<DynamicIVF_C> index, 
     index_ = index;
     current_scan_fraction_ = 1.0;
 
-    // initial the latency estimator
-    latency_estimator_ = std::make_shared<ListScanLatencyEstimator>(index_->d_, latency_grid_n_values_, latency_grid_k_values_, n_trials_);
-    latency_estimator_->profile_scan_latency();
+    // Specify the file where you want to store or load the profile
+    std::string profile_filename = "latency_profile.csv";
+
+    // Create the latency estimator
+    latency_estimator_ = std::make_shared<ListScanLatencyEstimator>(
+        index_->d_,
+        latency_grid_n_values_,
+        latency_grid_k_values_,
+        n_trials_,
+        false,
+        profile_filename);
+
 }
 
 float QueryCostMaintenance::compute_alpha_for_window() {

--- a/test/cpp/dynamic_ivf.cpp
+++ b/test/cpp/dynamic_ivf.cpp
@@ -32,12 +32,12 @@ Tensor generate_sequential_ids(int64_t num_vectors) {
 // Test fixture for DynamicIVF_C
 class DynamicIVFTest : public ::testing::Test {
 protected:
-    int dimension = 128;
+    int dimension = 3;
     int nlist = 100;
     int nprobe = 5;
     int num_codebooks = 8;
     int code_size = 8;
-    int num_vectors = 100000;
+    int num_vectors = 10000;
     int num_queries = 1;
     Tensor data_vectors;
     Tensor data_ids;

--- a/test/cpp/latency_estimator.cpp
+++ b/test/cpp/latency_estimator.cpp
@@ -3,103 +3,184 @@
 // Prompt for GitHub Copilot:
 // - Conform to the google style guide
 // - Use descriptive variable names
+//
 
-// list_scan_latency_estimator_test.cpp
-
-#include "maintenance_policies.h"
-#include "list_scanning.h"
 #include <gtest/gtest.h>
+#include "latency_estimation.h"
+#include "list_scanning.h"  // Must include your scan_list(...) definition
+#include <cstdio>           // For remove()
 
 // Helper function to measure actual latency for given n and k
-float measure_actual_latency(const ListScanLatencyEstimator& estimator, int n, int k) {
-    // Generate random vectors
-    torch::Tensor vectors = torch::rand({n, estimator.d_});
-    torch::Tensor ids = torch::randperm(n);
-    torch::Tensor query = torch::rand({estimator.d_});
+static float measure_actual_latency(const ListScanLatencyEstimator& estimator,
+                                    int n, int k) {
+  // Generate random vectors
+  torch::Tensor vectors = torch::rand({n, estimator.d_});
+  torch::Tensor ids = torch::randperm(n);
+  torch::Tensor query = torch::rand({estimator.d_});
 
-    TopkBuffer topk_buffer(k, false);
+  TopkBuffer topk_buffer(k, false);
 
-    const float* query_ptr = query.data_ptr<float>();
-    const float* vectors_ptr = vectors.data_ptr<float>();
-    const int64_t* ids_ptr = ids.data_ptr<int64_t>();
+  const float* query_ptr = query.data_ptr<float>();
+  const float* vectors_ptr = vectors.data_ptr<float>();
+  const int64_t* ids_ptr = ids.data_ptr<int64_t>();
 
-    uint64_t total_latency_ns = 0;
-    for (int m = 0; m < estimator.n_trials_; ++m) {
-        auto start = std::chrono::high_resolution_clock::now();
-        scan_list(query_ptr, vectors_ptr, ids_ptr, n, estimator.d_, topk_buffer);
-        auto end = std::chrono::high_resolution_clock::now();
+  uint64_t total_latency_ns = 0;
+  for (int m = 0; m < estimator.n_trials_; ++m) {
+    auto start = std::chrono::high_resolution_clock::now();
+    scan_list(query_ptr, vectors_ptr, ids_ptr, n, estimator.d_, topk_buffer);
+    auto end = std::chrono::high_resolution_clock::now();
 
-        auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-        total_latency_ns += duration.count();
-    }
-    double mean_latency_ns = static_cast<double>(total_latency_ns) / estimator.n_trials_;
-    return static_cast<float>(mean_latency_ns);
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+    total_latency_ns += duration.count();
+  }
+  double mean_latency_ns = static_cast<double>(total_latency_ns) / estimator.n_trials_;
+  return static_cast<float>(mean_latency_ns);
+}
+
+TEST(ListScanLatencyEstimatorTest, BasicInterpolationExtrapolation) {
+  // Use smaller grids for fast tests
+  int d = 8;
+  std::vector<int> n_values = {16, 32, 64};
+  std::vector<int> k_values = {1, 2, 4};
+  int n_trials = 2;  // small for testing
+
+  // Use a test file name (we'll remove it later)
+  std::string test_filename = "test_latency_profile.csv";
+  // Ensure it's not present at start
+  std::remove(test_filename.c_str());
+
+  ListScanLatencyEstimator estimator(d, n_values, k_values, n_trials,
+                                     /*adaptive_nprobe=*/false, test_filename);
+
+  // Because the file didn't exist, it should have profiled and created the file.
+  // Test that file was created
+  {
+    std::ifstream ifs(test_filename);
+    EXPECT_TRUE(ifs.good()) << "Profile file should be created.";
+  }
+
+  // Check some interpolation
+  // n=48 => between 32 and 64, k=3 => between 2 and 4
+  float latency = estimator.estimate_scan_latency(48, 3);
+  EXPECT_GT(latency, 0.0f) << "Should have a positive interpolated latency.";
+
+  // Check boundary conditions
+  float boundary1 = estimator.estimate_scan_latency(16, 1);
+  float boundary2 = estimator.estimate_scan_latency(64, 4);
+  EXPECT_GT(boundary1, 0.0f);
+  EXPECT_GT(boundary2, 0.0f);
+
+  // Below min n or k => should throw
+  EXPECT_THROW(estimator.estimate_scan_latency(1, 1), std::out_of_range);
+
+  // Clean up file
+  std::remove(test_filename.c_str());
+}
+
+TEST(ListScanLatencyEstimatorTest, ReloadFromFile) {
+  int d = 8;
+  std::vector<int> n_values = {16, 32};
+  std::vector<int> k_values = {1, 2};
+  int n_trials = 1;
+  std::string test_filename = "reload_test_profile.csv";
+  std::remove(test_filename.c_str());
+
+  // First instance => profiles, saves to file
+  {
+    ListScanLatencyEstimator estimator(d, n_values, k_values, n_trials,
+                                       false, test_filename);
+    // Just call something
+    float latency = estimator.estimate_scan_latency(16, 2);
+    EXPECT_GT(latency, 0.0f);
+  }
+
+  // Second instance => loads from the existing file, no fresh profiling
+  // We can detect this by artificially removing read permissions or
+  // by verifying it doesn't throw. We'll do a simpler check:
+  {
+    // We can store some timestamp or do an ephemeral test. For now, we trust
+    // that if the file exists, it tries to load. If it doesn't match grids,
+    // it won't load. So let's ensure it DOES match and it DOES load.
+
+    ListScanLatencyEstimator estimator2(d, n_values, k_values, n_trials,
+                                        false, test_filename);
+    float latency = estimator2.estimate_scan_latency(16, 1);
+    EXPECT_GT(latency, 0.0f) << "Should have loaded from file successfully.";
+  }
+
+  // Clean up
+  std::remove(test_filename.c_str());
+}
+
+TEST(ListScanLatencyEstimatorTest, MismatchedGridsForFile) {
+  int d = 8;
+  std::vector<int> n_values_1 = {16, 32};
+  std::vector<int> k_values_1 = {1, 2};
+  int n_trials = 1;
+  std::string test_filename = "mismatch_test_profile.csv";
+  std::remove(test_filename.c_str());
+
+  // First: create a file with certain n_values, k_values
+  {
+    ListScanLatencyEstimator estimator(d, n_values_1, k_values_1, n_trials,
+                                       false, test_filename);
+    float latency = estimator.estimate_scan_latency(32, 2);
+    EXPECT_GT(latency, 0.0f);
+  }
+
+  // Now create a new estimator with a different grid
+  std::vector<int> n_values_2 = {16, 32, 64};
+  ListScanLatencyEstimator estimator2(d, n_values_2, k_values_1, n_trials,
+                                      false, test_filename);
+  // Because the file grid won't match (mismatch in n_values), it should have
+  // re-profiled. We just do a basic call to confirm it works
+  float lat = estimator2.estimate_scan_latency(64, 2);
+  EXPECT_GT(lat, 0.0f);
+
+  // Clean up
+  std::remove(test_filename.c_str());
 }
 
 TEST(ListScanLatencyEstimatorTest, EstimateVsActualLatency) {
-    // Define dimensions and parameters
-    int d = 128;
-    std::vector<int> n_values = {16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576};
-    std::vector<int> k_values = {1, 4, 16, 64, 256, 1024};
-    int n_trials = 5;
+  int d = 32;
+  std::vector<int> n_values = {16, 64, 256};
+  std::vector<int> k_values = {1, 4, 16};
+  int n_trials = 3;
 
-    // Initialize the estimator
-    ListScanLatencyEstimator estimator(d, n_values, k_values, n_trials);
+  // In practice, you might have a bigger grid, but let's keep it short for test
+  ListScanLatencyEstimator estimator(d, n_values, k_values, n_trials);
 
-    // Profile the scan latency
-    auto start = std::chrono::high_resolution_clock::now();
-    estimator.profile_scan_latency();
-    auto end = std::chrono::high_resolution_clock::now();
-    std::cout << "Profiled scan latency in "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
-              << " ms" << std::endl;
+  // Profile is performed in constructor if not already loaded from file
+  std::vector<std::pair<int, int>> test_cases = {
+      {16, 4},
+      {64, 1},
+      {64, 16},
+      {256, 16},
+      {100, 5},   // interpolation
+      {300, 16},  // interpolation
+      {512, 16},  // extrapolation
+  };
 
-    // Define test cases: pairs of (n, k)
-    std::vector<std::pair<int, int>> test_cases = {
-        // Interpolation Cases
-        {1500, 15},    // n between 1024 and 4096, k between 16 and 64
-        {3000, 30},    // n between 1024 and 4096, k between 16 and 64
-        {7500, 75},    // n between 4096 and 16384, k between 64 and 256
-        {12000, 120},  // n between 4096 and 16384, k between 64 and 256
-        {500, 5},      // n between 256 and 1024, k between 4 and 16
-        {10000, 150},  // n between 4096 and 16384, k between 64 and 256
-        {11000, 200},  // n between 4096 and 16384, k between 64 and 256
-
-        // Extrapolation Cases
-        {2000000, 2048}, // n and k exceed maximum grid values
-        {8, 0},           // n and k below minimum grid values
-        {32, 2},          // n and k below minimum grid values but within positive range
-        {1048577, 1025},  // n just above maximum, k just above maximum
-        {5000, 2048},     // k exceeds maximum
-        {2097152, 64},    // n exceeds maximum
-    };
-    for (const auto& [n, k] : test_cases) {
-        if (n < n_values.front() || k < k_values.front()) {
-            // Expect an exception for below minimum values
-            EXPECT_THROW({
-                estimator.estimate_scan_latency(n, k);
-            }, std::out_of_range);
-            continue;
-        }
-
-        try {
-            // Estimate the latency
-            float estimated_latency_ns = estimator.estimate_scan_latency(n, k);
-
-            // Measure the actual latency
-            float actual_latency_ns = measure_actual_latency(estimator, n, k);
-
-            float estimated_latency = estimated_latency_ns / 1e6;  // Convert to milliseconds
-            float actual_latency = actual_latency_ns / 1e6;        // Convert to milliseconds
-
-            std::cout << "Estimated latency: " << estimated_latency << " ms, Actual latency: " << actual_latency << " ms" << std::endl;
-
-            // Allow a reasonable tolerance, e.g., 20% difference
-            float tolerance = 0.2f * actual_latency;
-            EXPECT_NEAR(estimated_latency, actual_latency, tolerance)
-                << "Failed for n=" << n << ", k=" << k;
-        } catch (const std::exception& e) {
-            FAIL() << "Exception for n=" << n << ", k=" << k << ": " << e.what();
-        }
+  for (auto& tc : test_cases) {
+    int n = tc.first;
+    int k = tc.second;
+    if (n < n_values.front() || k < k_values.front()) {
+      EXPECT_THROW(estimator.estimate_scan_latency(n, k), std::out_of_range);
+      continue;
     }
+
+    float estimated_latency_ns = estimator.estimate_scan_latency(n, k);
+    float actual_latency_ns = measure_actual_latency(estimator, n, k);
+
+    float estimated_ms = estimated_latency_ns / 1e6f;
+    float actual_ms = actual_latency_ns / 1e6f;
+    std::cout << "n=" << n << ", k=" << k
+              << " => estimated=" << estimated_ms << "ms, actual=" << actual_ms
+              << "ms\n";
+
+    // Tolerance of 40% because these are quite approximate with small n_trials
+    float tolerance = 0.4f * actual_ms;
+    EXPECT_NEAR(estimated_ms, actual_ms, tolerance)
+        << "Difference is too large for n=" << n << ", k=" << k;
+  }
 }


### PR DESCRIPTION
Addresses #8 

The latency estimation profile is run and saved to a file, reused for future use. This saves a significant amount of time in the tests, as previously, the profile was regenerated for each instance of the index.