### PR TITLE
Fix typo in the command for running the example program.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,7 +46,7 @@ Run the example by executing the following command:
 
 .. code-block:: bash
 
-    python examples/basic_example.py
+    python examples/quickstart.py
 
 This program will:
 - Build an index from a sample dataset.


### PR DESCRIPTION
Fix a typo in Step 4 of the ‘Running Examples’ section: update the command from `python examples/basic_example.py` to `python examples/quickstart.py`
