### PR TITLE
Add docs, comments, and additional tests to the IndexPartition class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 if(QUAKE_USE_NUMA)
     add_compile_definitions(QUAKE_USE_NUMA)
-else()
+endif()
 
 # C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,19 +16,9 @@ else()
     set(FAISS_ENABLE_GPU OFF)
 endif()
 
-# QUAKE_USE_NUMA: Enable NUMA support
-# Default: OFF
 if(QUAKE_USE_NUMA)
-    set(QUAKE_USE_NUMA ON)
+    add_compile_definitions(QUAKE_USE_NUMA)
 else()
-    set(QUAKE_USE_NUMA OFF)
-endif()
-
-if(QUAKE_USE_AVX512)
-    set(QUAKE_USE_AVX512 ON)
-else()
-    set(QUAKE_USE_AVX512 OFF)
-endif()
 
 # C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,5 +11,6 @@ Quake Documentation
    install
    development_guide
    api
+   architecture/index_partition
 
 * :ref:`genindex`

--- a/src/cpp/include/index_partition.h
+++ b/src/cpp/include/index_partition.h
@@ -9,66 +9,191 @@
 
 #include <common.h>
 
+/**
+ * @brief Represents a partition (sub-index) of encoded vectors.
+ *
+ * The IndexPartition class manages a contiguous block of encoded vectors (codes)
+ * and their corresponding vector IDs. It supports appending new entries, updating
+ * and removing existing ones, and dynamically resizing the underlying memory.
+ */
 class IndexPartition {
 public:
-    int numa_node_ = -1;
-    int thread_id_ = -1;
+    int numa_node_ = -1;    ///< Assigned NUMA node (-1 if not set)
+    int thread_id_ = -1;    ///< Mapped thread ID for processing
 
-    int64_t buffer_size_ = 0;   // Allocated capacity (number of vectors)
-    int64_t num_vectors_ = 0;   // Current number of vectors
-    int64_t code_size_ = 0;     // Size of each code in bytes (must be set before operations)
+    int64_t buffer_size_ = 0;   ///< Allocated capacity (in number of vectors)
+    int64_t num_vectors_ = 0;   ///< Current number of stored vectors
+    int64_t code_size_ = 0;     ///< Size of each code in bytes (must be set before adding vectors)
 
-    uint8_t* codes_ = nullptr;  // Encoded vectors
-    idx_t* ids_ = nullptr;      // Vector IDs
+    uint8_t* codes_ = nullptr;  ///< Pointer to the encoded vectors (raw memory block)
+    idx_t* ids_ = nullptr;      ///< Pointer to the vector IDs
 
+    /// Default constructor.
     IndexPartition() = default;
 
+    /**
+     * @brief Parameterized constructor.
+     *
+     * Initializes the partition with a given number of vectors and copies in the provided codes and IDs.
+     *
+     * @param num_vectors The initial number of vectors.
+     * @param codes Pointer to the buffer holding the encoded vectors.
+     * @param ids Pointer to the vector IDs.
+     * @param code_size Size of each code in bytes.
+     */
     IndexPartition(int64_t num_vectors,
                    uint8_t* codes,
                    idx_t* ids,
                    int64_t code_size);
 
+    /**
+     * @brief Move constructor.
+     *
+     * Transfers the contents from another partition into this one.
+     *
+     * @param other The partition to move from.
+     */
     IndexPartition(IndexPartition&& other) noexcept;
 
+    /**
+     * @brief Move assignment operator.
+     *
+     * Transfers the contents from another partition into this one, clearing existing data.
+     *
+     * @param other The partition to move from.
+     * @return Reference to this partition.
+     */
     IndexPartition& operator=(IndexPartition&& other) noexcept;
 
+    /// Destructor. Frees all allocated memory.
     ~IndexPartition();
 
-    // Set the code size (if not known at construction time)
+    /**
+     * @brief Set the code size.
+     *
+     * Must be called before any vectors are added. Throws an error if vectors already exist.
+     *
+     * @param code_size The size in bytes for each vector code.
+     */
     void set_code_size(int64_t code_size);
 
-    // Append new entries to the end of this partition
+    /**
+     * @brief Append new entries to the partition.
+     *
+     * Appends n_entry new vectors (codes and IDs) at the end of the partition.
+     *
+     * @param n_entry Number of new vectors to append.
+     * @param new_ids Pointer to the new vector IDs.
+     * @param new_codes Pointer to the new encoded vectors.
+     */
     void append(int64_t n_entry, const idx_t* new_ids, const uint8_t* new_codes);
 
-    // Update existing entries in place
+    /**
+     * @brief Update existing entries in place.
+     *
+     * Overwrites n_entry entries starting from the given offset.
+     *
+     * @param offset The starting index of the update.
+     * @param n_entry Number of entries to update.
+     * @param new_ids Pointer to the new vector IDs.
+     * @param new_codes Pointer to the new encoded vectors.
+     */
     void update(int64_t offset, int64_t n_entry, const idx_t* new_ids, const uint8_t* new_codes);
 
-    // Remove an entry at a given index (swap last element into this position)
+    /**
+     * @brief Remove an entry from the partition.
+     *
+     * Removes the vector at the given index by swapping in the last vector.
+     *
+     * @param index Index of the vector to remove.
+     */
     void remove(int64_t index);
 
-    // Reserve capacity for at least new_capacity entries
+    /**
+     * @brief Resize the partition.
+     *
+     * Ensures that the internal buffer has capacity for at least new_capacity entries.
+     * If new_capacity is less than the current number of vectors, the partition is truncated.
+     *
+     * @param new_capacity The desired capacity (number of vectors).
+     */
     void resize(int64_t new_capacity);
 
-    // Clear all memory and reset
+    /**
+     * @brief Clear the partition.
+     *
+     * Frees all allocated memory and resets the partition state.
+     */
     void clear();
 
-    // Find the index of a given ID (linear search)
+    /**
+     * @brief Find the index of a vector by its ID.
+     *
+     * Performs a linear search.
+     *
+     * @param id The vector ID to search for.
+     * @return The index of the vector if found; -1 otherwise.
+     */
     int64_t find_id(idx_t id) const;
 
+    /**
+     * @brief Reallocate internal memory to a new capacity.
+     *
+     * Allocates new memory for a given capacity and copies existing data.
+     *
+     * @param new_capacity The new capacity (number of vectors).
+     */
     void reallocate_memory(int64_t new_capacity);
 
 #ifdef QUAKE_USE_NUMA
-    // Set the NUMA node and move data there if necessary
+    /**
+     * @brief Set the NUMA node for the partition.
+     *
+     * Moves the memory to the specified NUMA node if necessary.
+     *
+     * @param new_numa_node The target NUMA node.
+     */
     void set_numa_node(int new_numa_node);
 #endif
 
 private:
+    /**
+     * @brief Move data from another partition.
+     *
+     * Helper for move constructor and move assignment.
+     *
+     * @param other The partition to move from.
+     */
     void move_from(IndexPartition&& other);
+
+    /**
+     * @brief Free the allocated memory.
+     *
+     * Releases the codes and IDs buffers.
+     */
     void free_memory();
+
+    /**
+     * @brief Ensure capacity.
+     *
+     * Checks that the internal buffer can hold at least the required number of vectors,
+     * and resizes if necessary.
+     *
+     * @param required The minimum required number of vectors.
+     */
     void ensure_capacity(int64_t required);
 
+    /**
+     * @brief Allocate memory for a given type.
+     *
+     * Allocates memory for num_elements of type T, optionally on a specific NUMA node.
+     *
+     * @tparam T The data type.
+     * @param num_elements The number of elements to allocate.
+     * @param numa_node The NUMA node (-1 for default allocation).
+     * @return Pointer to the allocated memory.
+     */
     template <typename T>
     T* allocate_memory(size_t num_elements, int numa_node);
 };
-
 #endif //INDEX_PARTITION_H

--- a/src/cpp/src/dynamic_inverted_list.cpp
+++ b/src/cpp/src/dynamic_inverted_list.cpp
@@ -529,7 +529,7 @@ int DynamicInvertedLists::get_numa_node(size_t list_no) {
     if (it == partitions_.end()) {
         throw std::runtime_error("List does not exist in get_numa_node");
     }
-    return it->second.numa_node_;
+    return it->second->numa_node_;
 }
 
 void DynamicInvertedLists::set_numa_node(size_t list_no, int new_numa_node, bool interleaved) {
@@ -537,15 +537,15 @@ void DynamicInvertedLists::set_numa_node(size_t list_no, int new_numa_node, bool
     if (it == partitions_.end()) {
         throw std::runtime_error("List does not exist in set_numa_node");
     }
-    it->second.set_numa_node(new_numa_node);
+    it->second->set_numa_node(new_numa_node);
 }
 
-std::set<size_t> DynamicInvertedLists::get_unassigned_clusters() {
+set<size_t> DynamicInvertedLists::get_unassigned_clusters() {
     // Now we need a way to track unassigned clusters.
     // If you consider "unassigned" as numa_node_ = -1:
     std::set<size_t> result;
     for (auto &kv : partitions_) {
-        if (kv.second.numa_node_ == -1) {
+        if (kv.second->numa_node_ == -1) {
             result.insert(kv.first);
         }
     }
@@ -557,7 +557,7 @@ int DynamicInvertedLists::get_thread(size_t list_no) {
     if (it == partitions_.end()) {
         throw std::runtime_error("List does not exist in get_thread");
     }
-    return it->second.thread_id_;
+    return it->second->thread_id_;
 }
 
 void DynamicInvertedLists::set_thread(size_t list_no, int new_thread_id) {
@@ -565,7 +565,7 @@ void DynamicInvertedLists::set_thread(size_t list_no, int new_thread_id) {
     if (it == partitions_.end()) {
         throw std::runtime_error("List does not exist in set_thread");
     }
-    it->second.thread_id_ = new_thread_id;
+    it->second->thread_id_ = new_thread_id;
 }
 
 #endif

--- a/src/cpp/src/dynamic_inverted_list.cpp
+++ b/src/cpp/src/dynamic_inverted_list.cpp
@@ -540,7 +540,7 @@ void DynamicInvertedLists::set_numa_node(size_t list_no, int new_numa_node, bool
     it->second->set_numa_node(new_numa_node);
 }
 
-set<size_t> DynamicInvertedLists::get_unassigned_clusters() {
+std::set<size_t> DynamicInvertedLists::get_unassigned_clusters() {
     // Now we need a way to track unassigned clusters.
     // If you consider "unassigned" as numa_node_ = -1:
     std::set<size_t> result;

--- a/src/cpp/src/index_partition.cpp
+++ b/src/cpp/src/index_partition.cpp
@@ -229,13 +229,19 @@ void IndexPartition::ensure_capacity(int64_t required) {
 
 template <typename T>
 T* IndexPartition::allocate_memory(size_t num_elements, int numa_node) {
+    size_t total_bytes = num_elements * sizeof(T);
+    T* ptr = nullptr;
 #ifdef QUAKE_USE_NUMA
     if (numa_node == -1) {
-        return reinterpret_cast<T*>(std::malloc(num_elements * sizeof(T)));
+        ptr = reinterpret_cast<T*>(std::malloc(total_bytes));
     } else {
-        return reinterpret_cast<T*>(numa_alloc_onnode(num_elements * sizeof(T), numa_node));
+        ptr = reinterpret_cast<T*>(numa_alloc_onnode(total_bytes, numa_node));
     }
 #else
-    return reinterpret_cast<T*>(std::malloc(num_elements * sizeof(T)));
+    ptr = reinterpret_cast<T*>(std::malloc(total_bytes));
 #endif
+    if (!ptr) {
+        throw std::bad_alloc();
+    }
+    return ptr;
 }

--- a/test/cpp/index_partition.cpp
+++ b/test/cpp/index_partition.cpp
@@ -630,7 +630,7 @@ TEST_F(IndexPartitionTest, ConcurrentFindIdTest) {
 
 #ifdef QUAKE_USE_NUMA
 #include <numa.h>
-TEST_F(IndexPartitionExtraTest, NumaSetNodeTest) {
+TEST_F(IndexPartitionTest, NumaSetNodeTest) {
     if (numa_available() == -1) {
         GTEST_SKIP() << "NUMA not available on this system.";
     }


### PR DESCRIPTION
Cleans up the IndexPartition class and adds:
- A documentation page
- Doxygen format comments to header file
- Additional tests on concurrent reads, large appends, and NUMA allocation
- Bug fixes for NUMA specific code