### PR TITLE
Add docs and additional tests for partition manager

### DIFF
--- a/docs/architecture/dynamic_inverted_list.rst
+++ b/docs/architecture/dynamic_inverted_list.rst
@@ -1,0 +1,40 @@
+DynamicInvertedLists Class Design
+===================================
+
+Overview
+--------
+
+The ``DynamicInvertedLists`` class provides a dynamic, NUMA-aware inverted list implementation
+by extending the Faiss ``InvertedLists`` interface. Internally, it manages a collection of partitions,
+each represented by an instance of the ``IndexPartition`` class, which holds a contiguous block
+of vector codes and corresponding IDs.
+
+Key Responsibilities
+--------------------
+
+- **Data Management:**
+  Each partition stores a set of encoded vectors and their IDs. Partitions are stored in an
+  unordered map, enabling dynamic creation and deletion.
+
+- **Dynamic Operations:**
+  Supports adding, updating, and removing entries both within a single partition and across
+  partitions (batch updates).
+
+- **NUMA Awareness:**
+  Offers methods to set and get NUMA node details for each partition. This facilitates better data
+  locality in NUMA systems, allowing memory allocations to be placed on specific nodes.
+
+- **Faiss Compatibility:**
+  Implements all the required virtual methods from the Faiss ``InvertedLists`` interface so that
+  it can be seamlessly used in Faiss-based search and clustering workflows.
+
+- **Serialization:**
+  Provides functionality to serialize (save) and deserialize (load) the entire inverted list structure,
+  including partition data and metadata.
+
+Limitations
+-----------
+
+- The ``resize`` method is currently a no-op because the partitions are stored in a map.
+- The lookup within each partition (using a linear search via ``find_id``) is simple but may become
+  inefficient for very large partitions.

--- a/docs/architecture/partition_manager.rst
+++ b/docs/architecture/partition_manager.rst
@@ -1,0 +1,49 @@
+PartitionManager Class Documentation
+========================================
+
+Overview
+--------
+The PartitionManager class is a higher-level coordinator for managing the partitions of a dynamic IVF index.
+It provides the logic for initializing, modifying, and maintaining partitions. Internally, it relies on a DynamicInvertedLists object—which handles the low‐level
+storage of vector codes and IDs using a map of IndexPartition objects—to actually store the data, and the MaintenancePolicy object to determine when to perform partition reconfiguration.
+
+Key Responsibilities
+--------------------
+- **Initialization:**
+  Use a clustering result (a Clustering object) to initialize partitions in the underlying DynamicInvertedLists.
+  This includes setting partition IDs, centroids, and assigning vectors to partitions.
+
+- **Vector Assignment and Modification:**
+  Add new vectors into appropriate partitions based on explicit assignments or by performing a search on the parent index.
+  It also handles the removal of vectors by their IDs.
+
+- **Partition Reconfiguration:**
+  Manage partition splits, merges, and refinement. PartitionManager provides methods for splitting a partition into
+  smaller clusters and for reassigning vectors when partitions are merged or refined.
+
+- **Distribution:**
+  Offer methods to distribute a flat index into multiple partitions (``distribute_flat``) or partitioned index (``distribute_partitions``) and assign partitions
+  across cores for parallel query processing.
+
+- **Serialization:**
+  Save and load the complete state of the partition manager (including all partitions) from disk.
+
+Differences from DynamicInvertedLists
+---------------------------------------
+DynamicInvertedLists is the low-level container that holds partitions (each as an IndexPartition) and provides basic
+operations for adding, updating, and retrieving vector codes and IDs. In contrast, PartitionManager adds an additional
+layer of high-level logic, such as:
+
+- Converting clustering results into a partitioned index.
+- Managing vector assignment across partitions.
+- Performing partition reconfiguration (splitting, refinement, deletion) in the context of the overall index.
+- Coordinating distribution across workers and serialization.
+
+Thus, while DynamicInvertedLists is responsible for the raw storage and basic CRUD operations, PartitionManager
+orchestrates these operations in the context of an evolving, partitioned index.
+
+Usage
+-----
+PartitionManager is intended to be used by the high-level index (e.g. QuakeIndex) to manage partitions during index
+construction and maintenance. It encapsulates the logic for partition initialization, vector assignment, and periodic
+reconfiguration of partitions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,5 +13,6 @@ Quake Documentation
    api
    architecture/index_partition
    architecture/dynamic_inverted_list
+   architecture/partition_manager
 
 * :ref:`genindex`


### PR DESCRIPTION
Contains:
- Documentation page for the partition manager
- Documentation page for dynamic inverted lists (oops did not add in #35)
- Additional tests to improve test coverage of the partition manager