### PR TITLE
Add graphviz dependency

### DIFF
--- a/environments/ubuntu-latest/conda.yaml
+++ b/environments/ubuntu-latest/conda.yaml
@@ -16,4 +16,5 @@ dependencies:
     - sphinx
     - sphinx_rtd_theme
     - sphinxcontrib-mermaid
+    - graphviz
 


### PR DESCRIPTION
This pull request includes a small change to the `environments/ubuntu-latest/conda.yaml` file. The change adds `graphviz` to the list of dependencies. This is needed so that sphinx properly builds graphviz diagrams.