### PR TITLE
Fix doc workflow pip install

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -22,7 +22,7 @@ jobs:
           git config --global --add safe.directory '*'
           eval "$(conda shell.bash hook)"
           conda activate quake-env
-          pip install .
+          pip install --no-use-pep517 .
 
       - name: Build Sphinx Documentation
         working-directory: docs


### PR DESCRIPTION
The change modifies the `pip install` command in the public doc workflow to use the `--no-use-pep517` flag. 