### PR TITLE
Add local workflow

### DIFF
--- a/.github/self_hosted_runner/docker-compose.yaml
+++ b/.github/self_hosted_runner/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3.3'
+services:
+  docker:
+    image: docker:20.10-dind
+    privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+    ports:
+      - "2375:2375"
+    volumes:
+      - ./worker_dev_1/runner:/runner
+  github-runner:
+    image: summerwind/actions-runner:latest
+    container_name: github-runner
+    environment:
+      - RUNNER_ALLOW_RUNASROOT=true
+      - RUNNER_NAME=local-gpu-numa-runner
+      - RUNNER_REPO=marius-team/quake
+      - RUNNER_TOKEN=<RUNNER_TOKEN>
+      - RUNNER_LABELS=local-gpu-numa-runner
+      - DOCKER_HOST=tcp://docker:2375
+    depends_on:
+      - docker
+    volumes:
+      - ./worker_dev_1/runner:/runner
+    restart: always

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -18,10 +18,7 @@ jobs:
       options: --user root
     steps:
       - name: Debug env
-        run: |
-          ls -lh /
-          ls -lh /__e/
-          ls -lh /*
+        run: ls -lh /
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,7 +15,12 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: --volume /var/run/docker.sock:/var/run/docker.sock:rw,z --user root
+      options: --user root
+    services:
+      docker:
+        image: docker:20.10-dind
+        ports:
+          - 2375:2375
 
     steps:
       - name: Who am I?

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-
+      options: >-
+        --volume /var/run/docker.sock:/var/run/docker.sock:rw,z
+        --user root
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -17,6 +17,12 @@ jobs:
       image: ${{ needs.setup-container.outputs.container_image }}
       options: --user root
     steps:
+      - name: Debug env
+        run: |
+          ls -lh /
+          ls -lh /__e/
+          ls -lh /*
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -1,7 +1,51 @@
-name: Test Runner
-on: [push]
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
-  test:
-    runs-on: [self-hosted, local-gpu-numa-runner]
+  setup-container:
+    uses: ./.github/workflows/container_setup.yaml
+
+  build_and_test:
+    needs: setup-container
+    runs-on: local-gpu-numa-runner
+    container:
+      image: ${{ needs.setup-container.outputs.container_image }}
     steps:
-      - run: echo "Hello World"
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build C++
+        run: |
+          git config --global --add safe.directory '*'
+          eval "$(conda shell.bash hook)"
+          conda activate quake-env
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+                -DQUAKE_USE_NUMA=OFF \
+                -DQUAKE_ENABLE_GPU=OFF \
+                -DBUILD_TESTS=ON \
+                -DQUAKE_USE_AVX512=OFF \
+                ../
+          make bindings -j2
+          make quake_tests -j2
+
+      - name: Run C++ Tests
+        shell: bash
+        run: |
+          ./build/test/cpp/quake_tests
+
+      - name: Run Python Tests
+        shell: bash
+        run: |
+          git config --global --add safe.directory '*'
+          eval "$(conda shell.bash hook)"
+          conda activate quake-env
+          pip install --no-use-pep517 .
+          pip install pytest
+          python -m pytest test/python

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,8 +15,15 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: --volume /var/run/docker.sock:/var/run/docker.sock --user root
+      options: --volume /var/run/docker.sock:/var/run/docker.sock:rw,z --user root
+
     steps:
+      - name: Who am I?
+      - run: id -a
+
+      - name: Check Docker Version
+      - run: /usr/local/bin/docker version --format '{{.Server.APIVersion}}'
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,9 +15,7 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: >-
-        --volume /usr/local/bin/node:/__e/node20/bin/node:ro
-        --user root
+      options: --user root
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -1,51 +1,7 @@
-name: Build and Test
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+name: Test Runner
+on: [push]
 jobs:
-  setup-container:
-    uses: ./.github/workflows/container_setup.yaml
-
-  build_and_test:
-    needs: setup-container
+  test:
     runs-on: [self-hosted, local-gpu-numa-runner]
-    container:
-      image: ${{ needs.setup-container.outputs.container_image }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Build C++
-        run: |
-          git config --global --add safe.directory '*'
-          eval "$(conda shell.bash hook)"
-          conda activate quake-env
-          mkdir -p build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-                -DQUAKE_USE_NUMA=OFF \
-                -DQUAKE_ENABLE_GPU=OFF \
-                -DBUILD_TESTS=ON \
-                -DQUAKE_USE_AVX512=OFF \
-                ../
-          make bindings -j2
-          make quake_tests -j2
-
-      - name: Run C++ Tests
-        shell: bash
-        run: |
-          ./build/test/cpp/quake_tests
-
-      - name: Run Python Tests
-        shell: bash
-        run: |
-          git config --global --add safe.directory '*'
-          eval "$(conda shell.bash hook)"
-          conda activate quake-env
-          pip install --no-use-pep517 .
-          pip install pytest
-          python -m pytest test/python
+      - run: echo "Hello World"

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
   build_and_test:
     needs: setup-container
-    runs-on: local-gpu-numa-runner
+    runs-on: [self-hosted, local-gpu-numa-runner]
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
     steps:

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,11 +15,7 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: --user root
     steps:
-      - name: Debug env
-        run: ls -lh /
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -36,8 +32,8 @@ jobs:
                 -DBUILD_TESTS=ON \
                 -DQUAKE_USE_AVX512=OFF \
                 ../
-          make bindings -j2
-          make quake_tests -j2
+          make bindings -j
+          make quake_tests -j
 
       - name: Run C++ Tests
         shell: bash

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -17,12 +17,6 @@ jobs:
       image: ${{ needs.setup-container.outputs.container_image }}
 
     steps:
-      - name: Who am I?
-        run: id -a
-
-      - name: Check Docker Version
-        run: /usr/local/bin/docker version --format '{{.Server.APIVersion}}'
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -1,0 +1,51 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  setup-container:
+    uses: ./.github/workflows/container_setup.yaml
+
+  build_and_test:
+    needs: setup-container
+    runs-on: local-gpu-numa-runner
+    container:
+      image: ${{ needs.setup-container.outputs.container_image }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build C++
+        run: |
+          git config --global --add safe.directory '*'
+          eval "$(conda shell.bash hook)"
+          conda activate quake-env
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+                -DQUAKE_USE_NUMA=OFF \
+                -DQUAKE_ENABLE_GPU=OFF \
+                -DBUILD_TESTS=ON \
+                -DQUAKE_USE_AVX512=OFF \
+                ../
+          make bindings -j2
+          make quake_tests -j2
+
+      - name: Run C++ Tests
+        shell: bash
+        run: |
+          ./build/test/cpp/quake_tests
+
+      - name: Run Python Tests
+        shell: bash
+        run: |
+          git config --global --add safe.directory '*'
+          eval "$(conda shell.bash hook)"
+          conda activate quake-env
+          pip install --no-use-pep517 .
+          pip install pytest
+          python -m pytest test/python

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,12 +15,6 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: --user root
-    services:
-      docker:
-        image: docker:20.10-dind
-        ports:
-          - 2375:2375
 
     steps:
       - name: Who am I?

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: local-gpu-numa-runner
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
-      options: --volume /var/run/docker.sock:/var/run/docker.sock
+      options: --volume /var/run/docker.sock:/var/run/docker.sock --user root
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ${{ needs.setup-container.outputs.container_image }}
       options: >-
-        --volume /var/run/docker.sock:/var/run/docker.sock:rw,z
+        --volume /usr/local/bin/node:/__e/node20/bin/node:ro
         --user root
     steps:
       - name: Checkout Repository

--- a/.github/workflows/local_runner_tests.yaml
+++ b/.github/workflows/local_runner_tests.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Who am I?
-      - run: id -a
+        run: id -a
 
       - name: Check Docker Version
-      - run: /usr/local/bin/docker version --format '{{.Server.APIVersion}}'
+        run: /usr/local/bin/docker version --format '{{.Server.APIVersion}}'
 
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a setup for self-hosted GitHub Actions runners using Docker and includes a workflow to build and test the project on the self-hosted runner. The key changes are the addition of a Docker Compose configuration and a new GitHub Actions workflow.

This allows for testing on machines with NUMA and GPUs, addressing #16 

Self-hosted runner setup:

* [`.github/self_hosted_runner/docker-compose.yaml`](diffhunk://#diff-2fcb43541edf13024e4580a4a1a499fa85e566d676f14ed2fdb22b5ef900ba54R1-R26): Added Docker Compose configuration to set up a Docker-in-Docker service and a GitHub Actions runner container.

Workflow for building and testing:

* [`.github/workflows/local_runner_tests.yaml`](diffhunk://#diff-cac3d075658959ffcb08f332bb58b3c06d59ba86b24b9290c72a0d76222876f9R1-R51): Added a new GitHub Actions workflow to build and test the project. This workflow includes steps to set up the container, build the C++ project, and run both C++ and Python tests.