### PR TITLE
Fix: cmakelists debug mode typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,13 +169,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${LINK_LIBS})
 IF(CMAKE_BUILD_TYPE MATCHES Debug AND QUAKE_USE_TSAN)
     message("Using thread sanitizer")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
-    set(CMAKE_MODULE_LINKER_FLAGS "{$CMAKE_MODULE_LINKER_FLAGS} -fsanitize=thread")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=thread")
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug AND QUAKE_USE_TSAN)
 
 IF(CMAKE_BUILD_TYPE MATCHES Debug AND QUAKE_USE_ASAN)
     message("Using address sanitizer")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize-recover=address")
-    set(CMAKE_MODULE_LINKER_FLAGS "{$CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug AND QUAKE_USE_ASAN)
 
 # ---------------------------------------------------------------

--- a/environments/ubuntu-cuda118/Dockerfile
+++ b/environments/ubuntu-cuda118/Dockerfile
@@ -43,7 +43,7 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 # -----------------------------
 # Copy in your conda environment YAML
 # -----------------------------
-COPY environments/ubuntu-cuda/conda.yaml /tmp/conda.yaml
+COPY environments/ubuntu-cuda118/conda.yaml /tmp/conda.yaml
 
 # Create quake-env
 RUN conda env create -f /tmp/conda.yaml && conda clean -afy

--- a/environments/ubuntu-cuda124/Dockerfile
+++ b/environments/ubuntu-cuda124/Dockerfile
@@ -43,7 +43,7 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 # -----------------------------
 # Copy in your conda environment YAML
 # -----------------------------
-COPY environments/ubuntu-cuda/conda.yaml /tmp/conda.yaml
+COPY environments/ubuntu-cuda124/conda.yaml /tmp/conda.yaml
 
 # Create quake-env
 RUN conda env create -f /tmp/conda.yaml && conda clean -afy


### PR DESCRIPTION
This pull request fixes a minor issue in the `CMakeLists.txt` file by correcting a typo in the `CMAKE_MODULE_LINKER_FLAGS` variable. The change ensures proper string interpolation for sanitizer flags.

* **Bug fix in CMake configuration:**
  - Corrected the syntax for `CMAKE_MODULE_LINKER_FLAGS` by replacing curly braces (`{}`) with the correct `${}` for string interpolation in two instances: one for the thread sanitizer and one for the address sanitizer.